### PR TITLE
Selective entrypoint generation and named entrypoints for the 3d compiler

### DIFF
--- a/doc/3d-lang.rst
+++ b/doc/3d-lang.rst
@@ -1168,14 +1168,17 @@ fields.::
      0........1........2........3........4........5........6........7........8.........9 
   TT:{        x                          |                 y                 |   tag    }
 
-This yields the following C interface, with two entry points. The first is to
-probe and validate a pointer to the type ``Indirect``, while the second is to
-validate a ``struct Indirect``.
+This yields the following C interface with the probe entry point to
+probe and validate a pointer to the type ``Indirect``:
 
 .. code-block:: c
 
-  BOOLEAN ProbeProbeAndCopyCheckIndirect(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr);
-  BOOLEAN ProbeCheckIndirect(uint8_t *base, uint32_t len);
+  uint32_t ProbeProbeAndCopyCheckIndirect(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+Since only ``entrypoint probe`` is declared (and not a plain ``entrypoint``),
+only the probe entry point appears in the header. If we also wanted a plain
+validation entry point, we would additionally write ``entrypoint`` before
+the type definition (see :ref:`Selective_Entrypoint_Generation` below).
 
 The specification is equivalent to the following, though more concise:
 
@@ -1248,7 +1251,7 @@ The example below shows how to use multiple probes:
 * One can also associate different probes on each field of a type.
 
 The resulting C interface contains multiple entry points, one for each variant
-of probing entry point, and one for the non-probing variant:
+of probing entry point:
 
 .. code-block:: c
 
@@ -1266,11 +1269,10 @@ of probing entry point, and one for the non-probing variant:
     uint64_t probeAddr,
     uint64_t providedSize);
 
-  BOOLEAN ProbeCheckMultiProbe(
-    EVERPARSE_COPY_BUFFER_T destT1,
-    EVERPARSE_COPY_BUFFER_T destT2,
-    uint8_t *base,
-    uint32_t len);
+Since only ``entrypoint probe`` attributes are declared on ``MultiProbe`` (no plain
+``entrypoint``), only the probe entry points appear in the public header. If a
+plain validation entry point were also desired, the user would add a plain
+``entrypoint`` attribute to the type definition.
 
 
 The ``providedSize`` argument on the first two function signatures allows the
@@ -1327,6 +1329,72 @@ pointer is non-null:
 
 * If the pointer is non-null, the probe function is called, and validation
   proceeds as in the non-null case.
+
+
+.. _Selective_Entrypoint_Generation:
+
+Selective Entrypoint Generation
+...............................
+
+By default, when a type is marked as an ``entrypoint``, 3d generates a
+validation entry point in the wrapper header. When combined with probe
+attributes, 3d generates entry points *only* for the kinds of entry points
+that the user explicitly declares.
+
+For example, if a type only has ``entrypoint probe`` attributes, only the
+probe entry points appear in the public header—the underlying validation
+wrapper is still generated in the ``.c`` file (as a ``static`` function)
+but is not exposed publicly:
+
+.. literalinclude:: Probe.3d
+  :language: 3d
+  :start-after: SNIPPET_START: selective entrypoint$
+  :end-before: SNIPPET_END: selective entrypoint$
+
+For ``ProbeOnly``, since only ``entrypoint probe`` is specified, only the probe
+entry point is public:
+
+.. code-block:: c
+
+  uint32_t ProbeProbeAndCopyCheckProbeOnly(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+For ``BothEntrypoints``, since both a plain ``entrypoint`` and an
+``entrypoint probe`` are declared, both entry points are public:
+
+.. code-block:: c
+
+  BOOLEAN ProbeCheckBothEntrypoints(uint8_t *base, uint32_t len);
+  uint32_t ProbeProbeAndCopyCheckBothEntrypoints(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+
+.. _Named_Entrypoints:
+
+Named Entrypoints
+.................
+
+By default, the names of entry points are auto-generated from the module name,
+probe function name, and type name (e.g., ``ProbeProbeAndCopyCheckIndirect``).
+One can override these names using the ``entrypoint(Name)`` syntax:
+
+.. literalinclude:: Probe.3d
+  :language: 3d
+  :start-after: SNIPPET_START: named entrypoint$
+  :end-before: SNIPPET_END: named entrypoint$
+
+This produces the following public entry points:
+
+.. code-block:: c
+
+  BOOLEAN ValidateMyData(uint8_t *base, uint32_t len);
+
+  uint32_t ProbeMyData(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+  BOOLEAN CheckAll(uint8_t *base, uint32_t len);
+  uint32_t ProbeAll(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+The name argument is optional: ``entrypoint`` without parentheses continues to
+use the auto-generated name. Named and unnamed entry points can be freely mixed
+on the same type.
 
 
 An End-to-end Executable Example

--- a/doc/3d-snapshot/Probe.c
+++ b/doc/3d-snapshot/Probe.c
@@ -1786,3 +1786,153 @@ ProbeValidateCoercePtr(
   return positionAfterCoercePtr0;
 }
 
+uint64_t
+ProbeValidateProbeOnly(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  BOOLEAN hasBytes;
+  KRML_MAYBE_UNUSED_VAR(Ctxt);
+  KRML_MAYBE_UNUSED_VAR(ErrorHandlerFn);
+  KRML_MAYBE_UNUSED_VAR(Input);
+  hasBytes = 8ULL <= (InputLength - StartPosition);
+  if (hasBytes)
+  {
+    return StartPosition + 8ULL;
+  }
+  return EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA, StartPosition);
+}
+
+uint64_t
+ProbeValidateBothEntrypoints(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  BOOLEAN hasBytes;
+  KRML_MAYBE_UNUSED_VAR(Ctxt);
+  KRML_MAYBE_UNUSED_VAR(ErrorHandlerFn);
+  KRML_MAYBE_UNUSED_VAR(Input);
+  hasBytes = 8ULL <= (InputLength - StartPosition);
+  if (hasBytes)
+  {
+    return StartPosition + 8ULL;
+  }
+  return EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA, StartPosition);
+}
+
+uint64_t
+ProbeValidateNamedPlainEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  BOOLEAN hasBytes;
+  KRML_MAYBE_UNUSED_VAR(Ctxt);
+  KRML_MAYBE_UNUSED_VAR(ErrorHandlerFn);
+  KRML_MAYBE_UNUSED_VAR(Input);
+  hasBytes = 8ULL <= (InputLength - StartPosition);
+  if (hasBytes)
+  {
+    return StartPosition + 8ULL;
+  }
+  return EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA, StartPosition);
+}
+
+uint64_t
+ProbeValidateNamedProbeEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  BOOLEAN hasBytes;
+  KRML_MAYBE_UNUSED_VAR(Ctxt);
+  KRML_MAYBE_UNUSED_VAR(ErrorHandlerFn);
+  KRML_MAYBE_UNUSED_VAR(Input);
+  hasBytes = 8ULL <= (InputLength - StartPosition);
+  if (hasBytes)
+  {
+    return StartPosition + 8ULL;
+  }
+  return EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA, StartPosition);
+}
+
+uint64_t
+ProbeValidateNamedBothEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+)
+{
+  BOOLEAN hasBytes;
+  KRML_MAYBE_UNUSED_VAR(Ctxt);
+  KRML_MAYBE_UNUSED_VAR(ErrorHandlerFn);
+  KRML_MAYBE_UNUSED_VAR(Input);
+  hasBytes = 8ULL <= (InputLength - StartPosition);
+  if (hasBytes)
+  {
+    return StartPosition + 8ULL;
+  }
+  return EverParseSetValidatorErrorPos(EVERPARSE_VALIDATOR_ERROR_NOT_ENOUGH_DATA, StartPosition);
+}
+

--- a/doc/3d-snapshot/Probe.h
+++ b/doc/3d-snapshot/Probe.h
@@ -163,6 +163,96 @@ ProbeValidateCoercePtr(
   uint64_t StartPosition
 );
 
+uint64_t
+ProbeValidateProbeOnly(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+);
+
+uint64_t
+ProbeValidateBothEntrypoints(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+);
+
+uint64_t
+ProbeValidateNamedPlainEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+);
+
+uint64_t
+ProbeValidateNamedProbeEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+);
+
+uint64_t
+ProbeValidateNamedBothEp(
+  uint8_t *Ctxt,
+  void
+  (*ErrorHandlerFn)(
+    EVERPARSE_STRING x0,
+    EVERPARSE_STRING x1,
+    EVERPARSE_STRING x2,
+    uint64_t x3,
+    uint8_t *x4,
+    uint8_t *x5,
+    uint64_t x6
+  ),
+  uint8_t *Input,
+  uint64_t InputLength,
+  uint64_t StartPosition
+);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/doc/3d-snapshot/ProbeWrapper.c
+++ b/doc/3d-snapshot/ProbeWrapper.c
@@ -74,7 +74,7 @@ BOOLEAN ProbeCheckV(EVERPARSE_COPY_BUFFER_T destS, EVERPARSE_COPY_BUFFER_T destT
 	return TRUE;
 }
 
-BOOLEAN ProbeCheckIndirect(uint8_t *base, uint32_t len) {
+static BOOLEAN ProbeCheckIndirect(uint8_t *base, uint32_t len) {
 	EVERPARSE_ERROR_FRAME frame;
 	uint64_t result;
 	frame.filled = FALSE;
@@ -131,7 +131,7 @@ BOOLEAN ProbeCheckI(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len) {
 	return TRUE;
 }
 
-BOOLEAN ProbeCheckMultiProbe(EVERPARSE_COPY_BUFFER_T destT1, EVERPARSE_COPY_BUFFER_T destT2, uint8_t *base, uint32_t len) {
+static BOOLEAN ProbeCheckMultiProbe(EVERPARSE_COPY_BUFFER_T destT1, EVERPARSE_COPY_BUFFER_T destT2, uint8_t *base, uint32_t len) {
 	EVERPARSE_ERROR_FRAME frame;
 	uint64_t result;
 	frame.filled = FALSE;
@@ -227,4 +227,184 @@ BOOLEAN ProbeCheckCoercePtr(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_
 		return FALSE;
 	}
 	return TRUE;
+}
+
+static BOOLEAN ProbeCheckProbeOnly(uint8_t *base, uint32_t len) {
+	EVERPARSE_ERROR_FRAME frame;
+	uint64_t result;
+	frame.filled = FALSE;
+	result = ProbeValidateProbeOnly( (uint8_t*)&frame, &DefaultErrorHandler, base, len, 0);
+	if (EverParseIsError(result))
+	{
+		if (frame.filled)
+		{
+			ProbeEverParseError(frame.typename_s, frame.fieldname, frame.reason);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t ProbeProbeAndCopyCheckProbeOnly(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize) {
+	uint8_t *base;
+	if(providedSize < 8U)
+	{
+		// Not enough space for probe
+		return EVERPARSE_PROBE_FAILURE_INCORRECT_SIZE;
+	}
+	if(!ProbeInit("ProbeCheckProbeOnly", 8U, probeDest))
+	{
+		// ProbeInit failed
+		return EVERPARSE_PROBE_FAILURE_INIT;
+	}
+	if (!ProbeAndCopy(8U, 0, 0, probeAddr, probeDest))
+	{
+		// Probe failed
+		return EVERPARSE_PROBE_FAILURE_PROBE;
+	}
+	base = EverParseStreamOf(probeDest);
+	if (!ProbeCheckProbeOnly( base, 8U))
+	{
+		return EVERPARSE_PROBE_FAILURE_VALIDATION;
+	}
+	return EVERPARSE_SUCCESS;
+}
+
+BOOLEAN ProbeCheckBothEntrypoints(uint8_t *base, uint32_t len) {
+	EVERPARSE_ERROR_FRAME frame;
+	uint64_t result;
+	frame.filled = FALSE;
+	result = ProbeValidateBothEntrypoints( (uint8_t*)&frame, &DefaultErrorHandler, base, len, 0);
+	if (EverParseIsError(result))
+	{
+		if (frame.filled)
+		{
+			ProbeEverParseError(frame.typename_s, frame.fieldname, frame.reason);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t ProbeProbeAndCopyCheckBothEntrypoints(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize) {
+	uint8_t *base;
+	if(providedSize < 8U)
+	{
+		// Not enough space for probe
+		return EVERPARSE_PROBE_FAILURE_INCORRECT_SIZE;
+	}
+	if(!ProbeInit("ProbeCheckBothEntrypoints", 8U, probeDest))
+	{
+		// ProbeInit failed
+		return EVERPARSE_PROBE_FAILURE_INIT;
+	}
+	if (!ProbeAndCopy(8U, 0, 0, probeAddr, probeDest))
+	{
+		// Probe failed
+		return EVERPARSE_PROBE_FAILURE_PROBE;
+	}
+	base = EverParseStreamOf(probeDest);
+	if (!ProbeCheckBothEntrypoints( base, 8U))
+	{
+		return EVERPARSE_PROBE_FAILURE_VALIDATION;
+	}
+	return EVERPARSE_SUCCESS;
+}
+
+BOOLEAN ValidateMyData(uint8_t *base, uint32_t len) {
+	EVERPARSE_ERROR_FRAME frame;
+	uint64_t result;
+	frame.filled = FALSE;
+	result = ProbeValidateNamedPlainEp( (uint8_t*)&frame, &DefaultErrorHandler, base, len, 0);
+	if (EverParseIsError(result))
+	{
+		if (frame.filled)
+		{
+			ProbeEverParseError(frame.typename_s, frame.fieldname, frame.reason);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
+
+static BOOLEAN ProbeCheckNamedProbeEp(uint8_t *base, uint32_t len) {
+	EVERPARSE_ERROR_FRAME frame;
+	uint64_t result;
+	frame.filled = FALSE;
+	result = ProbeValidateNamedProbeEp( (uint8_t*)&frame, &DefaultErrorHandler, base, len, 0);
+	if (EverParseIsError(result))
+	{
+		if (frame.filled)
+		{
+			ProbeEverParseError(frame.typename_s, frame.fieldname, frame.reason);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t ProbeMyData(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize) {
+	uint8_t *base;
+	if(providedSize < 8U)
+	{
+		// Not enough space for probe
+		return EVERPARSE_PROBE_FAILURE_INCORRECT_SIZE;
+	}
+	if(!ProbeInit("ProbeCheckNamedProbeEp", 8U, probeDest))
+	{
+		// ProbeInit failed
+		return EVERPARSE_PROBE_FAILURE_INIT;
+	}
+	if (!ProbeAndCopy(8U, 0, 0, probeAddr, probeDest))
+	{
+		// Probe failed
+		return EVERPARSE_PROBE_FAILURE_PROBE;
+	}
+	base = EverParseStreamOf(probeDest);
+	if (!ProbeCheckNamedProbeEp( base, 8U))
+	{
+		return EVERPARSE_PROBE_FAILURE_VALIDATION;
+	}
+	return EVERPARSE_SUCCESS;
+}
+
+BOOLEAN CheckAll(uint8_t *base, uint32_t len) {
+	EVERPARSE_ERROR_FRAME frame;
+	uint64_t result;
+	frame.filled = FALSE;
+	result = ProbeValidateNamedBothEp( (uint8_t*)&frame, &DefaultErrorHandler, base, len, 0);
+	if (EverParseIsError(result))
+	{
+		if (frame.filled)
+		{
+			ProbeEverParseError(frame.typename_s, frame.fieldname, frame.reason);
+		}
+		return FALSE;
+	}
+	return TRUE;
+}
+
+uint32_t ProbeAll(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize) {
+	uint8_t *base;
+	if(providedSize < 8U)
+	{
+		// Not enough space for probe
+		return EVERPARSE_PROBE_FAILURE_INCORRECT_SIZE;
+	}
+	if(!ProbeInit("CheckAll", 8U, probeDest))
+	{
+		// ProbeInit failed
+		return EVERPARSE_PROBE_FAILURE_INIT;
+	}
+	if (!ProbeAndCopy(8U, 0, 0, probeAddr, probeDest))
+	{
+		// Probe failed
+		return EVERPARSE_PROBE_FAILURE_PROBE;
+	}
+	base = EverParseStreamOf(probeDest);
+	if (!CheckAll( base, 8U))
+	{
+		return EVERPARSE_PROBE_FAILURE_VALIDATION;
+	}
+	return EVERPARSE_SUCCESS;
 }

--- a/doc/3d-snapshot/ProbeWrapper.h
+++ b/doc/3d-snapshot/ProbeWrapper.h
@@ -25,13 +25,9 @@ BOOLEAN ProbeCheckU(EVERPARSE_COPY_BUFFER_T destS, EVERPARSE_COPY_BUFFER_T destT
 
 BOOLEAN ProbeCheckV(EVERPARSE_COPY_BUFFER_T destS, EVERPARSE_COPY_BUFFER_T destT, uint8_t *base, uint32_t len);
 
-BOOLEAN ProbeCheckIndirect(uint8_t *base, uint32_t len);
-
 uint32_t ProbeProbeAndCopyCheckIndirect(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
 
 BOOLEAN ProbeCheckI(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len);
-
-BOOLEAN ProbeCheckMultiProbe(EVERPARSE_COPY_BUFFER_T destT1, EVERPARSE_COPY_BUFFER_T destT2, uint8_t *base, uint32_t len);
 
 uint32_t ProbeProbeAndCopyCheckMultiProbe(EVERPARSE_COPY_BUFFER_T destT1, EVERPARSE_COPY_BUFFER_T destT2, EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
 
@@ -40,6 +36,20 @@ uint32_t ProbeProbeAndCopyAltCheckMultiProbe(EVERPARSE_COPY_BUFFER_T destT1, EVE
 BOOLEAN ProbeCheckMaybeT(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len);
 
 BOOLEAN ProbeCheckCoercePtr(EVERPARSE_COPY_BUFFER_T dest, uint8_t *base, uint32_t len);
+
+uint32_t ProbeProbeAndCopyCheckProbeOnly(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+BOOLEAN ProbeCheckBothEntrypoints(uint8_t *base, uint32_t len);
+
+uint32_t ProbeProbeAndCopyCheckBothEntrypoints(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+BOOLEAN ValidateMyData(uint8_t *base, uint32_t len);
+
+uint32_t ProbeMyData(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
+
+BOOLEAN CheckAll(uint8_t *base, uint32_t len);
+
+uint32_t ProbeAll(EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize);
 #ifdef __cplusplus
 }
 #endif

--- a/doc/Probe.3d
+++ b/doc/Probe.3d
@@ -131,3 +131,39 @@ typedef struct _CoercePtr(EVERPARSE_COPY_BUFFER_T dest) {
   T(Bound) *pointer(UINT32) ptr probe ProbeAndCopy(length=sizeof(T), destination=dest);
 } CoercePtr;
 //SNIPPET_END: coerce$
+
+//SNIPPET_START: selective entrypoint$
+entrypoint probe ProbeAndCopy(length=sizeof(this))
+typedef struct _ProbeOnly {
+  UINT32 x;
+  UINT32 y;
+} ProbeOnly;
+
+entrypoint
+entrypoint probe ProbeAndCopy(length=sizeof(this))
+typedef struct _BothEntrypoints {
+  UINT32 x;
+  UINT32 y;
+} BothEntrypoints;
+//SNIPPET_END: selective entrypoint$
+
+//SNIPPET_START: named entrypoint$
+entrypoint(ValidateMyData)
+typedef struct _NamedPlainEp {
+  UINT32 x;
+  UINT32 y;
+} NamedPlainEp;
+
+entrypoint(ProbeMyData) probe ProbeAndCopy(length=sizeof(this))
+typedef struct _NamedProbeEp {
+  UINT32 x;
+  UINT32 y;
+} NamedProbeEp;
+
+entrypoint(CheckAll)
+entrypoint(ProbeAll) probe ProbeAndCopy(length=sizeof(this))
+typedef struct _NamedBothEp {
+  UINT32 x;
+  UINT32 y;
+} NamedBothEp;
+//SNIPPET_END: named entrypoint$

--- a/src/3d/Ast.fst
+++ b/src/3d/Ast.fst
@@ -596,7 +596,7 @@ type probe_entrypoint = {
 [@@ PpxDerivingYoJson ]
 noeq
 type attribute =
-  | Entrypoint: (probe: option probe_entrypoint) -> attribute
+  | Entrypoint: (ep_name: option ident) -> (probe: option probe_entrypoint) -> attribute
   | Aligned
   | Noextract
 
@@ -1141,8 +1141,10 @@ let print_generics generics =
 
 let print_attribute (a:attribute) : ML string =
   match a with
-  | Entrypoint None -> "entrypoint"
-  | Entrypoint (Some p) -> Printf.sprintf "entrypoint(probe(%s, length=%s)" (print_ident p.probe_ep_fn) (print_expr p.probe_ep_length)
+  | Entrypoint None None -> "entrypoint"
+  | Entrypoint (Some n) None -> Printf.sprintf "entrypoint(%s)" (print_ident n)
+  | Entrypoint None (Some p) -> Printf.sprintf "entrypoint probe(%s, length=%s)" (print_ident p.probe_ep_fn) (print_expr p.probe_ep_length)
+  | Entrypoint (Some n) (Some p) -> Printf.sprintf "entrypoint(%s) probe(%s, length=%s)" (print_ident n) (print_ident p.probe_ep_fn) (print_expr p.probe_ep_length)
   | Aligned -> "aligned"
   | Noextract -> "noextract"
 let print_attributes (a:list attribute) : ML string =
@@ -1262,14 +1264,31 @@ let print_decls (ds:list decl) : ML string =
 let has_entrypoint (l:list attribute) : Tot bool =
   List.Tot.existsb Entrypoint? l
 
+let has_plain_entrypoint (l:list attribute) : Tot bool =
+  List.Tot.existsb (fun a -> match a with Entrypoint _ None -> true | _ -> false) l
+
 let rec get_entrypoint_probes' (l: list attribute) (accu: list probe_entrypoint) : Tot (list probe_entrypoint) =
   match l with
   | [] -> List.Tot.rev accu
-  | Entrypoint (Some probe) :: q -> get_entrypoint_probes' q (probe :: accu)
+  | Entrypoint _ (Some probe) :: q -> get_entrypoint_probes' q (probe :: accu)
   | _ :: q -> get_entrypoint_probes' q accu
 
 let get_entrypoint_probes (l: list attribute) : Tot (list probe_entrypoint) =
   get_entrypoint_probes' l []
+
+let get_plain_entrypoint_name (l: list attribute) : Tot (option ident) =
+  match List.Tot.find (fun a -> match a with Entrypoint _ None -> true | _ -> false) l with
+  | Some (Entrypoint n None) -> n
+  | _ -> None
+
+let rec get_probe_entrypoint_names' (l: list attribute) (accu: list (option ident)) : Tot (list (option ident)) =
+  match l with
+  | [] -> List.Tot.rev accu
+  | Entrypoint n (Some _) :: q -> get_probe_entrypoint_names' q (n :: accu)
+  | _ :: q -> get_probe_entrypoint_names' q accu
+
+let get_probe_entrypoint_names (l: list attribute) : Tot (list (option ident)) =
+  get_probe_entrypoint_names' l []
 
 let is_entrypoint_or_export d = match d.d_decl.v with
   | Record names _ _ _ _

--- a/src/3d/Binding.fst
+++ b/src/3d/Binding.fst
@@ -2271,7 +2271,7 @@ let check_attribute
   (a: attribute)
 : ML attribute
 = match a with
-  | Entrypoint (Some p) ->
+  | Entrypoint ep_name (Some p) ->
     let ep_len = check_entrypoint_probe_length e p.probe_ep_length in
     let ep_init =
       match p.probe_ep_init with
@@ -2288,7 +2288,7 @@ let check_attribute
            error (Printf.sprintf "Probe function %s not found or not an init function" (print_ident i))
                  i.range)
     in
-    Entrypoint (Some ({
+    Entrypoint ep_name (Some ({
       p with probe_ep_init = ep_init; probe_ep_length = ep_len
     }))
   | _ -> a
@@ -2301,10 +2301,9 @@ let check_typedef_names
   let attrs = List.map (check_attribute env) tdnames.typedef_attributes in
   let eq_attrs a0 a1 =
     match a0, a1 with
-    | Entrypoint None, Entrypoint _
-    | Entrypoint _, Entrypoint None ->
+    | Entrypoint _ None, Entrypoint _ None ->
       true
-    | Entrypoint (Some p0), Entrypoint (Some p1) ->
+    | Entrypoint _ (Some p0), Entrypoint _ (Some p1) ->
       eq_idents p0.probe_ep_fn p1.probe_ep_fn
     | Aligned, Aligned
     | Noextract, Noextract -> true

--- a/src/3d/Deps.fst
+++ b/src/3d/Deps.fst
@@ -206,7 +206,7 @@ let scan_deps (fn:string) : ML scan_deps_t =
     | _ -> [] in
 
   let deps_of_attribute (a:attribute) : ML (list string) = match a with
-    | Entrypoint (Some p) -> maybe_dep p.probe_ep_fn `List.Tot.append` deps_of_expr p.probe_ep_length
+    | Entrypoint _ (Some p) -> maybe_dep p.probe_ep_fn `List.Tot.append` deps_of_expr p.probe_ep_length
     | _ -> []
   in
 

--- a/src/3d/Desugar.fst
+++ b/src/3d/Desugar.fst
@@ -436,8 +436,8 @@ and resolve_switch_case (env:qenv) (sc:switch_case) : ML switch_case = //case fi
 
 let resolve_typedef_attribute (env: qenv) (a: attribute) : ML attribute =
   match a with
-  | Entrypoint (Some p) ->
-    Entrypoint (Some ({
+  | Entrypoint ep_name (Some p) ->
+    Entrypoint ep_name (Some ({
       probe_ep_init = map_opt (resolve_ident env) p.probe_ep_init;
       probe_ep_fn = resolve_ident env p.probe_ep_fn;
       probe_ep_length = resolve_expr env p.probe_ep_length;

--- a/src/3d/Simplify.fst
+++ b/src/3d/Simplify.fst
@@ -225,10 +225,10 @@ let check_probe_size_range (e: expr) : ML unit =
 
 let simplify_attribute (env: T.env_t) (attr: attribute) : ML attribute =
   match attr with
-  | Entrypoint (Some p) ->
+  | Entrypoint ep_name (Some p) ->
     let e' = simplify_expr env p.probe_ep_length in
     check_probe_size_range e';
-    Entrypoint (Some ({
+    Entrypoint ep_name (Some ({
       p with
         probe_ep_length = e';
     }))

--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -737,6 +737,8 @@ let print_definition (mname:string) (d:decl { Definition? (fst d)} ) : ML string
       td_params = params;
       td_entrypoint_probes = [];
       td_entrypoint = false;
+      td_entrypoint_plain = false;
+      td_entrypoint_plain_name = None;
       td_noextract = false;
     } in
     Printf.sprintf "%slet %s : %s = %s\n\n"
@@ -1151,17 +1153,18 @@ let print_c_entry
     (* Main wrapper *)
     let pparams = print_params params in
     let pargs = print_arguments params in
-    let signature =
+    let mk_main_signature (name: string) =
       if is_input_stream_buffer 
       then Printf.sprintf
             "BOOLEAN %s(%suint8_t *base, uint32_t len)"
-             wrapper_name
+             name
              pparams
       else Printf.sprintf
             "uint64_t %s(%sEVERPARSE_INPUT_STREAM_BASE base)"
-             wrapper_name
+             name
              pparams
     in
+    let signature = mk_main_signature wrapper_name in
     let validator_name = validator_name modul d.decl_name.td_name.A.v.A.name in
     let body = 
       if is_input_stream_buffer
@@ -1169,28 +1172,54 @@ let print_c_entry
       else wrapped_call_stream validator_name pargs
     in
     (* Probe wrapper *)
-    let probe_wrapper_signature probe : ML _ =
+    let probe_wrapper_signature (probe: probe_entrypoint) : ML _ =
       if not is_input_stream_buffer
       then ( //fail gracefully with an error message
         Ast.error "Top-level probe wrappers only for input stream buffer"
           probe.probe_ep_fn.range
       );
       let return_type = "uint32_t" in
-      let probe_fn = probe_fn_to_c probe.probe_ep_fn in
-      let probe_wrapper_name = probe_wrapper_name modul probe_fn d.decl_name.td_name.A.v.A.name in
+      let public_name =
+        match probe.probe_ep_name with
+        | Some n -> A.ident_name n
+        | None ->
+          let probe_fn = probe_fn_to_c probe.probe_ep_fn in
+          probe_wrapper_name modul probe_fn d.decl_name.td_name.A.v.A.name
+      in
       Printf.sprintf
             "%s %s(%sEVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize)"
              return_type
-             probe_wrapper_name
+             public_name
              pparams
+    in
+    (* Collecting everything together *)
+    let has_probes = Cons? d.decl_name.td_entrypoint_probes in
+    let effective_main_name =
+      if d.decl_name.td_entrypoint_plain then
+        match d.decl_name.td_entrypoint_plain_name with
+        | Some n -> A.ident_name n
+        | None -> wrapper_name
+      else wrapper_name
     in
     let probe_wrapper (probe: probe_entrypoint) : ML _ =
       constr_wrapper
         (probe_wrapper_signature probe)
-        (wrapped_call_probe_buffer wrapper_name pargs probe)
+        (wrapped_call_probe_buffer effective_main_name pargs probe)
     in
-    (* Collecting everything together *)
-    constr_wrapper signature body :: List.map probe_wrapper d.decl_name.td_entrypoint_probes
+    let main_wrapper =
+      if d.decl_name.td_entrypoint_plain then
+        (* Plain entrypoint declared: expose in header with custom name if provided *)
+        let public_signature = mk_main_signature effective_main_name in
+        constr_wrapper public_signature body
+      else if has_probes then
+        (* Only probe entrypoints: main wrapper is internal (static), not in header *)
+        let static_signature = "static " ^ signature in
+        ("", impl static_signature body)
+      else
+        (* Should not happen since we only get here if td_entrypoint is true *)
+        constr_wrapper signature body
+    in
+    main_wrapper :: List.map probe_wrapper d.decl_name.td_entrypoint_probes
   in
 
   let signatures_output_typ_deps =
@@ -1250,7 +1279,7 @@ let print_c_entry
        #endif\n"
       error_code_macros
       external_defs_includes
-      (signatures |> String.concat "\n\n")
+      (signatures |> List.filter (fun s -> s <> "") |> String.concat "\n\n")
   in
   let input_stream_include = HashingOptions.input_stream_include input_stream_binding in
   let header =

--- a/src/3d/Target.fsti
+++ b/src/3d/Target.fsti
@@ -239,6 +239,7 @@ type typedef_body =
 
 noeq
 type probe_entrypoint = {
+  probe_ep_name: option A.ident;
   probe_ep_init: A.ident;
   probe_ep_fn: A.ident;
   probe_ep_length: expr;
@@ -250,6 +251,8 @@ type typedef_name = {
   td_params:list param;
   td_entrypoint_probes: list probe_entrypoint;
   td_entrypoint:bool;
+  td_entrypoint_plain:bool;
+  td_entrypoint_plain_name: option A.ident;
   td_noextract:bool;
 }
 type typedef = typedef_name & typedef_body

--- a/src/3d/TranslateForInterpreter.fst
+++ b/src/3d/TranslateForInterpreter.fst
@@ -403,6 +403,7 @@ let rec translate_typ (t:A.typ) : ML (T.typ & T.decls) =
     T.T_arrow ts t, List.flatten ds @ d
 
 let translate_probe_entrypoint
+  (ep_name: option A.ident)
   (p: A.probe_entrypoint)
 : ML T.probe_entrypoint
 = let init =
@@ -411,6 +412,7 @@ let translate_probe_entrypoint
     | Some i -> i
   in
   {
+    probe_ep_name = ep_name;
     probe_ep_init = init;
     probe_ep_fn = p.probe_ep_fn;
     probe_ep_length = translate_expr p.probe_ep_length;
@@ -433,13 +435,17 @@ let translate_typedef_name (tdn:A.typedef_names) (params:list Ast.param)
   : ML (T.typedef_name & T.decls) =
 
   let params, ds = translate_params params in
-  let entrypoint_probes = List.map translate_probe_entrypoint (A.get_entrypoint_probes tdn.typedef_attributes) in
+  let probe_names = A.get_probe_entrypoint_names tdn.typedef_attributes in
+  let probes = A.get_entrypoint_probes tdn.typedef_attributes in
+  let entrypoint_probes = List.map2 translate_probe_entrypoint probe_names probes in
 
   let open T in
   { td_name = tdn.typedef_name;
     td_params = params;
     td_entrypoint_probes = entrypoint_probes;
     td_entrypoint = has_entrypoint tdn.typedef_attributes;
+    td_entrypoint_plain = A.has_plain_entrypoint tdn.typedef_attributes;
+    td_entrypoint_plain_name = A.get_plain_entrypoint_name tdn.typedef_attributes;
     td_noextract = List.existsb Noextract? tdn.typedef_attributes }, ds
 
 let make_enum_typ (t:T.typ) (ids:list ident) =
@@ -1215,6 +1221,8 @@ let hoist_one_type_definition (should_inline:bool)
           td_params = List.rev env;
           td_entrypoint_probes = [];
           td_entrypoint = false;
+          td_entrypoint_plain = false;
+          td_entrypoint_plain_name = None;
       } in
       let t_parser = parse_typ orig_tdn.td_name type_name body in
       add_parser_kind_nz genv tdn.td_name t_parser.p_kind.pk_nz t_parser.p_kind.pk_weak_kind;

--- a/src/3d/ocaml/parser.mly
+++ b/src/3d/ocaml/parser.mly
@@ -455,11 +455,21 @@ cases:
   | cs=nonempty_list(case) { cs }
 
 attribute:
-  | ENTRYPOINT { Entrypoint None }
+  | ENTRYPOINT { Entrypoint (None, None) }
+  | ENTRYPOINT LPAREN name=IDENT RPAREN { Entrypoint (Some name, None) }
   | ENTRYPOINT PROBE i=qident LPAREN length=IDENT EQ len=expr RPAREN {
       if length.v.name <> "length" || length.v.modul_name <> None
       then error "Expected 'length' as the first argument to 'entrypoint probe'" length.range;
-      Entrypoint (Some ({
+      Entrypoint (None, Some ({
+        probe_ep_init = None;
+        probe_ep_fn = i;
+        probe_ep_length = len;
+      }))
+    }
+  | ENTRYPOINT LPAREN name=IDENT RPAREN PROBE i=qident LPAREN length=IDENT EQ len=expr RPAREN {
+      if length.v.name <> "length" || length.v.modul_name <> None
+      then error "Expected 'length' as the first argument to 'entrypoint probe'" length.range;
+      Entrypoint (Some name, Some ({
         probe_ep_init = None;
         probe_ep_fn = i;
         probe_ep_length = len;

--- a/src/3d/tests/probe/src/Probe.3d
+++ b/src/3d/tests/probe/src/Probe.3d
@@ -41,3 +41,22 @@ typedef struct _primaryAndCopy(EVERPARSE_COPY_BUFFER_T dest) {
   UINT64 bound;
   secondary(bound) *payload probe ProbeAndCopy (length = 4, destination = dest);
 } primaryAndCopy;
+
+entrypoint(ValidateMyStruct)
+typedef struct _namedPlain {
+  UINT16 x;
+  UINT16 y { y >= x };
+} namedPlain;
+
+entrypoint(ProbeMyStruct) probe ProbeInPlace (length = PROBE_LENGTH)
+typedef struct _namedProbe {
+  UINT16 x;
+  UINT16 y { y >= x };
+} namedProbe;
+
+entrypoint(CheckBoth)
+entrypoint(ProbeBoth) probe ProbeInPlace (length = 42)
+typedef struct _namedBoth {
+  UINT16 x;
+  UINT16 y { y >= x };
+} namedBoth;


### PR DESCRIPTION

### Summary

This PR implements two related features for the EverParse 3d compiler's entrypoint system:

1. **Selective entrypoint generation** — Only generate public wrapper entry points that the user explicitly declares. Previously, any type with `entrypoint probe` would *also* get a plain validation entry point in the public header, even if the user didn't ask for one. Now the header contains only what is declared.

2. **Named entrypoints** — A new `entrypoint(Name)` syntax that lets users control the generated function names instead of relying on the auto-generated `ModuleProbeCheckTypeName` convention.

### Motivation

When integrating EverParse-generated validators into OS kernel code, developers need precise control over:
- Which entry points appear in the public API (to avoid polluting the interface with unused wrappers)
- The names of those entry points (to match existing calling conventions or naming standards)

### New syntax

```
// Probe-only: only probe wrapper is public
entrypoint probe ProbeAndCopy(length = 42)
typedef struct _Foo { ... } Foo;

// Both plain and probe wrappers are public
entrypoint
entrypoint probe ProbeAndCopy(length = 42)
typedef struct _Foo { ... } Foo;

// Named entrypoints with custom public names
entrypoint(ValidateMyData)
entrypoint(ProbeMyData) probe ProbeAndCopy(length = 42)
typedef struct _Foo { ... } Foo;
```

### Design decisions

- **Internal wrapper always exists**: The main Check wrapper is always generated in the `.c` file. When not declared as a public entrypoint, it is marked `static`. This ensures probe wrappers (which internally call the main wrapper) continue to work correctly.
- **Custom names affect only public signatures**: The internal implementation uses stable auto-generated names. Custom names determine what appears in the public header and what probe wrappers call.
- **Backward compatible**: Bare `entrypoint` (without parentheses or probe qualifier) behaves exactly as before.

### Changes

**F\* sources** (compiler logic):
- `Ast.fst` — Extended `Entrypoint` attribute with optional name; added `has_plain_entrypoint`, `get_plain_entrypoint_name`, `get_probe_entrypoint_names` helpers
- `Target.fst/fsti` — Conditional wrapper generation (static vs public) with custom naming support; new fields `td_entrypoint_plain`, `td_entrypoint_plain_name`, `probe_ep_name`
- `TranslateForInterpreter.fst` — Propagates entrypoint names from AST to Target IR
- `Binding.fst` — Allows plain + probe entrypoints to coexist on same type
- `Desugar.fst`, `Simplify.fst`, `Deps.fst` — Updated pattern matches for new constructor shape

**Parser**:
- `parser.mly` — Grammar rules for `entrypoint(Name)` and `entrypoint(Name) probe ...`

**Documentation**:
- `doc/3d-lang.rst` — New sections "Selective Entrypoint Generation" and "Named Entrypoints" with examples; updated existing Indirect and MultiProbe examples to reflect new behavior
- `doc/Probe.3d` — Added snippet examples
- `doc/3d-snapshot/` — Updated expected output

**Tests**:
- `src/3d/tests/probe/src/Probe.3d` — Added test cases for named plain, named probe, and named both entrypoints

### Testing

- `src/3d/tests/probe`: Full pipeline test passes (3d → F* verification → KaRaMeL extraction → C compilation → execution)
- `doc/` tests: All `.3d` files compile, C tests pass, snapshot diffs pass, Sphinx HTML builds cleanly with `-W` (warnings-as-errors)
