### PR TITLE
Use EVERPARSE_PROBE_FAILURE_INIT instead of undefined EVERPARSE_PROBE…

### DIFF
--- a/src/3d/Target.fst
+++ b/src/3d/Target.fst
@@ -1092,7 +1092,7 @@ let print_c_entry
            len
      in
      if hoist then
-       (if goto_return then "uint32_t result = EVERPARSE_PROBE_FAILURE_UNIMPLEMENTED;\n\t" else "")
+       (if goto_return then "uint32_t result = EVERPARSE_PROBE_FAILURE_INIT;\n\t" else "")
        ^ Printf.sprintf "uint8_t *base%s;\n\t" scalar_zero
        ^ probe_prefix probe wrappedName ^ "\n\t"
        ^ (if goto_return then
@@ -1121,7 +1121,7 @@ let print_c_entry
               len
               tail)
      else
-       (if goto_return then "uint32_t result = EVERPARSE_PROBE_FAILURE_UNIMPLEMENTED;\n\t" else "")
+       (if goto_return then "uint32_t result = EVERPARSE_PROBE_FAILURE_INIT;\n\t" else "")
        ^ (if goto_return then
             Printf.sprintf 
               "%s\n\t\

--- a/src/3d/tests/goto_return/snapshot/GotoReturnWrapper.c
+++ b/src/3d/tests/goto_return/snapshot/GotoReturnWrapper.c
@@ -63,7 +63,7 @@ exit:
 }
 
 uint32_t GotoReturnProbeInPlaceCheckTagged(uint64_t bound, EVERPARSE_COPY_BUFFER_T probeDest, uint64_t probeAddr, uint64_t providedSize) {
-	uint32_t result = EVERPARSE_PROBE_FAILURE_UNIMPLEMENTED;
+	uint32_t result = EVERPARSE_PROBE_FAILURE_INIT;
 	if(providedSize < 42U)
 	{
 		// Not enough space for probe


### PR DESCRIPTION
…_FAILURE_UNIMPLEMENTED

The goto_for_early_return path initialized the result variable with EVERPARSE_PROBE_FAILURE_UNIMPLEMENTED which was never defined. Replace with EVERPARSE_PROBE_FAILURE_INIT which is already defined in the generated header.